### PR TITLE
Add branch override and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Github Sync NoAdmin
+
+This project contains a script for downloading a Python library from a GitHub repository, installing it into a temporary virtual environment and cleaning up afterwards. It is intended for quick demonstrations or pet projects on a single machine.
+
+## Environment Variables
+
+- `PYTHON_LIB_GITHUB_URL` – **required**. URL to the GitHub repository or a direct link to the zip archive.
+- `PYTHON_LIB_BRANCH` – optional. Branch name to use when forming the archive URL if the repository URL does not already point to a zip file. Defaults to `main`.
+
+## Running Tests
+
+Use `python -m pytest` from the repository root to run the automated tests.

--- a/deploy_library.py
+++ b/deploy_library.py
@@ -12,6 +12,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 REPO_URL_ENV_VAR = "PYTHON_LIB_GITHUB_URL"
 DEFAULT_BRANCH = "main"
+BRANCH_ENV_VAR = "PYTHON_LIB_BRANCH"
 
 def get_repo_url_from_env():
     """Return repository URL from environment variable."""
@@ -27,8 +28,9 @@ def download_repo_zip(repo_url, temp_dir_path):
         if repo_url.endswith(".zip"):
             zip_url = repo_url
         else:
+            branch = os.environ.get(BRANCH_ENV_VAR, DEFAULT_BRANCH)
             cleaned = repo_url.rstrip("/")
-            zip_url = f"{cleaned}/archive/refs/heads/{DEFAULT_BRANCH}.zip"
+            zip_url = f"{cleaned}/archive/refs/heads/{branch}.zip"
         response = requests.get(zip_url, stream=True, timeout=30)
         response.raise_for_status()
         zip_file_path = Path(temp_dir_path) / "repo.zip"

--- a/tests/test_deploy_library.py
+++ b/tests/test_deploy_library.py
@@ -34,6 +34,17 @@ class DeployLibraryTests(TestCase):
                 self.assertIsNotNone(zip_path)
                 self.assertEqual(zip_path.read_bytes(), dummy_data)
 
+    def test_download_repo_zip_branch_override(self):
+        dummy_data = b'TESTDATA'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_path = Path(tmpdir)
+            with mock.patch.dict(os.environ, {dl.BRANCH_ENV_VAR: 'feature'}):
+                with mock.patch('requests.get', return_value=DummyResponse(dummy_data)) as mock_get:
+                    zip_path = dl.download_repo_zip('https://example.com/repo', temp_path)
+                    self.assertIsNotNone(zip_path)
+                    expected_url = 'https://example.com/repo/archive/refs/heads/feature.zip'
+                    mock_get.assert_called_with(expected_url, stream=True, timeout=30)
+
     def test_extract_repo_zip(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)


### PR DESCRIPTION
## Summary
- add `BRANCH_ENV_VAR` constant and use it when downloading zip archives
- update tests to cover branch override
- document the new variable in `README`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2c807ce48320996c2704ea6339b0