### PR TITLE
Fix demo script version lookup

### DIFF
--- a/deploy_library.py
+++ b/deploy_library.py
@@ -103,8 +103,8 @@ def run_demonstration(venv_path, library_name):
     demo_script = Path(venv_path) / "demo_script.py"
     demo_code = (
         f"import {library_name}\n"
-        f"version = getattr({library_name}, '__version__', 'unknown')\n"
-        f"print(f'Версия библиотеки {library_name}: {version}')\n"
+        f"version = getattr({library_name}, '__version__', getattr({library_name}, 'version', 'unknown'))\n"
+        f"print(f'Версия библиотеки {library_name}: {{version}}')\n"
     )
     try:
         demo_script.write_text(demo_code, encoding="utf-8")


### PR DESCRIPTION
## Summary
- check both `__version__` and `version` attributes in demo script
- ensure demonstration prints library version using either attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2c7eb9cc8320be5954af5277c4ba