### PR TITLE
Fix library import name for demo

### DIFF
--- a/deploy_library.py
+++ b/deploy_library.py
@@ -8,10 +8,13 @@ import shutil
 import logging
 from pathlib import Path
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 REPO_URL_ENV_VAR = "PYTHON_LIB_GITHUB_URL"
 DEFAULT_BRANCH = "main"
+
 
 def get_repo_url_from_env():
     """Return repository URL from environment variable."""
@@ -20,6 +23,7 @@ def get_repo_url_from_env():
         logging.error(f"Переменная окружения {REPO_URL_ENV_VAR} не установлена.")
         return None
     return repo_url.strip()
+
 
 def download_repo_zip(repo_url, temp_dir_path):
     """Download repository archive and return path to the zip file."""
@@ -42,16 +46,18 @@ def download_repo_zip(repo_url, temp_dir_path):
         logging.error(f"Не удалось скачать архив: {exc}")
         return None
 
+
 def extract_repo_zip(zip_path, extract_to_dir_path):
     """Extract zip archive to directory."""
     try:
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(extract_to_dir_path)
         logging.info(f"Архив распакован в {extract_to_dir_path}")
         return extract_to_dir_path
     except Exception as exc:
         logging.error(f"Не удалось распаковать архив: {exc}")
         return None
+
 
 def find_library_root(extract_to_dir_path):
     """Find top-level library directory."""
@@ -66,10 +72,15 @@ def find_library_root(extract_to_dir_path):
         logging.error(f"Ошибка при поиске корневой папки: {exc}")
         return None
 
+
 def create_virtual_env(venv_path):
     """Create virtual environment."""
     try:
-        result = subprocess.run([sys.executable, "-m", "venv", str(venv_path)], capture_output=True, text=True)
+        result = subprocess.run(
+            [sys.executable, "-m", "venv", str(venv_path)],
+            capture_output=True,
+            text=True,
+        )
         if result.returncode != 0:
             logging.error(f"Не удалось создать виртуальное окружение: {result.stderr}")
             return False
@@ -79,13 +90,18 @@ def create_virtual_env(venv_path):
         logging.error(f"Ошибка при создании виртуального окружения: {exc}")
         return False
 
+
 def install_library_in_venv(venv_path, library_source_path):
     """Install library into virtual environment."""
     pip_dir = "Scripts" if os.name == "nt" else "bin"
     pip_exe = "pip.exe" if os.name == "nt" else "pip"
     pip_path = Path(venv_path) / pip_dir / pip_exe
     try:
-        result = subprocess.run([str(pip_path), "install", str(library_source_path)], capture_output=True, text=True)
+        result = subprocess.run(
+            [str(pip_path), "install", str(library_source_path)],
+            capture_output=True,
+            text=True,
+        )
         if result.returncode != 0:
             logging.error(f"Ошибка установки библиотеки: {result.stderr}")
             return False
@@ -94,6 +110,7 @@ def install_library_in_venv(venv_path, library_source_path):
     except Exception as exc:
         logging.error(f"Не удалось установить библиотеку: {exc}")
         return False
+
 
 def run_demonstration(venv_path, library_name):
     """Run small demonstration script inside virtual environment."""
@@ -108,7 +125,9 @@ def run_demonstration(venv_path, library_name):
     )
     try:
         demo_script.write_text(demo_code, encoding="utf-8")
-        result = subprocess.run([str(python_path), str(demo_script)], capture_output=True, text=True)
+        result = subprocess.run(
+            [str(python_path), str(demo_script)], capture_output=True, text=True
+        )
         logging.info(f"Демонстрация вывода: {result.stdout.strip()}")
         if result.stderr:
             logging.warning(f"Сообщения ошибки демонстрации: {result.stderr.strip()}")
@@ -118,6 +137,7 @@ def run_demonstration(venv_path, library_name):
         if demo_script.exists():
             demo_script.unlink()
 
+
 def cleanup(paths_to_remove):
     """Remove temporary directories."""
     for path in paths_to_remove:
@@ -126,6 +146,7 @@ def cleanup(paths_to_remove):
             logging.info(f"Удалена директория {path}")
         except Exception as exc:
             logging.error(f"Не удалось удалить {path}: {exc}")
+
 
 def main():
     logging.info("Начало процесса развертывания Python библиотеки.")
@@ -153,7 +174,7 @@ def main():
         library_root_path = find_library_root(extracted_content_path)
         if not library_root_path:
             return
-        library_name_for_import = Path(repo_url_str.strip("/")).name
+        library_name_for_import = library_root_path.name
         if not create_virtual_env(venv_dir_path):
             return
         if not install_library_in_venv(venv_dir_path, library_root_path):
@@ -167,6 +188,7 @@ def main():
         logging.info("Запуск процесса очистки...")
         cleanup(paths_to_clean)
         logging.info("Очистка завершена.")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_deploy_library.py
+++ b/tests/test_deploy_library.py
@@ -7,14 +7,18 @@ from unittest import mock, TestCase
 
 import deploy_library as dl
 
+
 class DummyResponse:
     def __init__(self, data: bytes):
         self.data = data
         self.status_code = 200
+
     def raise_for_status(self):
         pass
+
     def iter_content(self, chunk_size=1):
         yield self.data
+
 
 class DeployLibraryTests(TestCase):
     def test_get_repo_url_from_env_missing(self):
@@ -22,52 +26,83 @@ class DeployLibraryTests(TestCase):
             self.assertIsNone(dl.get_repo_url_from_env())
 
     def test_get_repo_url_from_env_present(self):
-        with mock.patch.dict(os.environ, {dl.REPO_URL_ENV_VAR: 'https://example.com'}):
-            self.assertEqual(dl.get_repo_url_from_env(), 'https://example.com')
+        with mock.patch.dict(os.environ, {dl.REPO_URL_ENV_VAR: "https://example.com"}):
+            self.assertEqual(dl.get_repo_url_from_env(), "https://example.com")
 
     def test_download_repo_zip(self):
-        dummy_data = b'TESTDATA'
+        dummy_data = b"TESTDATA"
         with tempfile.TemporaryDirectory() as tmpdir:
             temp_path = Path(tmpdir)
-            with mock.patch('requests.get', return_value=DummyResponse(dummy_data)):
-                zip_path = dl.download_repo_zip('https://example.com/repo.zip', temp_path)
+            with mock.patch("requests.get", return_value=DummyResponse(dummy_data)):
+                zip_path = dl.download_repo_zip(
+                    "https://example.com/repo.zip", temp_path
+                )
                 self.assertIsNotNone(zip_path)
                 self.assertEqual(zip_path.read_bytes(), dummy_data)
 
     def test_extract_repo_zip(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
-            zip_file = tmp_path / 'archive.zip'
-            with zipfile.ZipFile(zip_file, 'w') as zf:
-                zf.writestr('file.txt', 'content')
-            extract_dir = tmp_path / 'extract'
+            zip_file = tmp_path / "archive.zip"
+            with zipfile.ZipFile(zip_file, "w") as zf:
+                zf.writestr("file.txt", "content")
+            extract_dir = tmp_path / "extract"
             extract_dir.mkdir()
             self.assertIsNotNone(dl.extract_repo_zip(zip_file, extract_dir))
-            self.assertTrue((extract_dir / 'file.txt').is_file())
+            self.assertTrue((extract_dir / "file.txt").is_file())
 
     def test_find_library_root(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
-            root_dir = tmp_path / 'libroot'
+            root_dir = tmp_path / "libroot"
             root_dir.mkdir()
-            (root_dir / '__init__.py').write_text('')
+            (root_dir / "__init__.py").write_text("")
             self.assertEqual(dl.find_library_root(tmp_path), root_dir)
 
     def test_create_virtual_env(self):
-        with mock.patch('subprocess.run') as mock_run:
+        with mock.patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess([], 0)
-            self.assertTrue(dl.create_virtual_env(Path('venv')))
+            self.assertTrue(dl.create_virtual_env(Path("venv")))
 
     def test_install_library_in_venv(self):
-        with mock.patch('subprocess.run') as mock_run:
+        with mock.patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess([], 0)
-            self.assertTrue(dl.install_library_in_venv(Path('venv'), Path('lib')))
+            self.assertTrue(dl.install_library_in_venv(Path("venv"), Path("lib")))
 
     def test_cleanup(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
-            dir_to_remove = tmp_path / 'dir'
+            dir_to_remove = tmp_path / "dir"
             dir_to_remove.mkdir()
-            (dir_to_remove / 'file.txt').write_text('data')
+            (dir_to_remove / "file.txt").write_text("data")
             dl.cleanup([dir_to_remove])
             self.assertFalse(dir_to_remove.exists())
+
+    def test_main_zip_url_uses_library_root_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            root_dir = tmp_path / "project-main"
+            root_dir.mkdir()
+            (root_dir / "__init__.py").write_text("")
+            zip_file = tmp_path / "archive.zip"
+            with zipfile.ZipFile(zip_file, "w") as zf:
+                zf.writestr("dummy", "content")
+            with mock.patch.dict(
+                os.environ, {dl.REPO_URL_ENV_VAR: "https://example.com/project.zip"}
+            ), mock.patch(
+                "deploy_library.download_repo_zip", return_value=zip_file
+            ), mock.patch(
+                "deploy_library.extract_repo_zip", return_value=tmp_path
+            ), mock.patch(
+                "deploy_library.find_library_root", return_value=root_dir
+            ), mock.patch(
+                "deploy_library.create_virtual_env", return_value=True
+            ), mock.patch(
+                "deploy_library.install_library_in_venv", return_value=True
+            ), mock.patch(
+                "deploy_library.run_demonstration"
+            ) as mock_demo:
+                dl.main()
+                mock_demo.assert_called_once()
+                args, _ = mock_demo.call_args
+                self.assertEqual(args[1], root_dir.name)


### PR DESCRIPTION
## Summary
- derive the import name from the extracted folder
- add unit test for library name when URL ends with `.zip`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2c7d4eac83208b6570b8df688b2b